### PR TITLE
Fix URL query parameter serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domo"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Sean Murphy <sean.murphy@domo.com>"]
 edition = "2018"
 description = "The Domo Rust SDK wrapping our APIs. Also includes a CLI application."
@@ -22,6 +22,6 @@ serde_yaml = "0.8.11"
 
 structopt = "0.3.9"
 csv="1.1.3"
-surf = "2.0.0"
-async-std = {version = "1.6.5", features=["attributes"]}
-base64 = "0.12.3"
+surf = "2.1.0"
+async-std = {version = "1.9.0", features=["attributes"]}
+base64 = "0.13.0"

--- a/src/public/account/mod.rs
+++ b/src/public/account/mod.rs
@@ -92,6 +92,12 @@ pub struct Property {
     pub required: Option<bool>,
 }
 
+#[derive(Serialize)]
+struct ListParams {
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
 /// Account API methods
 /// Uses the form method_object
 impl super::Client {
@@ -103,13 +109,10 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Account>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("account").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = ListParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/accounts"))
             .query(&q)?
             .header("Authorization", at)
@@ -230,13 +233,10 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<AccountType>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("account").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = ListParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/account-types"))
             .query(&q)?
             .header("Authorization", at)

--- a/src/public/activity/mod.rs
+++ b/src/public/activity/mod.rs
@@ -50,6 +50,14 @@ pub struct LogEntry {
     pub ip_address: Option<String>,
 }
 
+#[derive(Serialize)]
+struct ListParams {
+    pub user_id: Option<u64>,
+    pub start: u64,
+    pub end: Option<u64>,
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
 /// Activity Log API methods
 /// Uses the form method_object
 impl super::Client {
@@ -70,20 +78,13 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<LogEntry>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("audit").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(uid) = user_id {
-            q.push(("user", uid.to_string()));
-        }
-        q.push(("start", start.to_string()));
-        if let Some(v) = end {
-            q.push(("end", v.to_string()));
-        }
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = ListParams {
+            user_id,
+            start,
+            end,
+            limit,
+            offset
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/audit"))
             .query(&q)?
             .header("Authorization", at)

--- a/src/public/group/mod.rs
+++ b/src/public/group/mod.rs
@@ -69,13 +69,15 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Group>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("user").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
+        #[derive(Serialize)]
+        struct ListParams {
+            pub limit: Option<u32>,
+            pub offset: Option<u32>,
         }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = ListParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/groups"))
             .query(&q)?
             .header("Authorization", at)

--- a/src/public/page/mod.rs
+++ b/src/public/page/mod.rs
@@ -128,13 +128,15 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Page>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("dashboard").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub limit: Option<u32>,
+            pub offset: Option<u32>,
         }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/pages"))
             .query(&q)?
             .header("Authorization", at)

--- a/src/public/stream/mod.rs
+++ b/src/public/stream/mod.rs
@@ -99,13 +99,15 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Stream>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("data").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub limit: Option<u32>,
+            pub offset: Option<u32>,
         }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/streams"))
             .query(&q)?
             .header("Authorization", at)
@@ -124,8 +126,15 @@ impl super::Client {
         dsid: &str,
     ) -> Result<Vec<Stream>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("data").await?;
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub q: String
+        }
+        let query = QueryParams {
+            q: String::from("dataSource.id:") + dsid
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/streams/search"))
-            .query(&[("q", String::from("dataSource.id:") + dsid)])?
+            .query(&query)?
             .header("Authorization", at)
             .await?;
         if !response.status().is_success() {
@@ -142,8 +151,15 @@ impl super::Client {
         dsoid: &str,
     ) -> Result<Vec<Stream>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("data").await?;
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub q: String
+        }
+        let query = QueryParams {
+            q: String::from("dataSource.owner.id:") + dsoid
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/streams/search"))
-            .query(&[("q", String::from("dataSource.owner.id:") + dsoid)])?
+            .query(&query)?
             .header("Authorization", at)
             .await?;
         if !response.status().is_success() {
@@ -258,13 +274,15 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Execution>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("data").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub limit: Option<u32>,
+            pub offset: Option<u32>,
         }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!(
             "{}{}{}{}",
             self.host, "/v1/streams/", id, "/executions"

--- a/src/public/user/mod.rs
+++ b/src/public/user/mod.rs
@@ -104,13 +104,15 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<User>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("user").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
+        #[derive(Serialize)]
+        struct QueryParams {
+            pub limit: Option<u32>,
+            pub offset: Option<u32>,
         }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/users"))
             .query(&q)?
             .header("Authorization", at)

--- a/src/public/workflow/mod.rs
+++ b/src/public/workflow/mod.rs
@@ -207,6 +207,12 @@ pub struct Attachment {
     pub mime_type: Option<String>,
 }
 
+#[derive(Serialize)]
+struct QueryParams {
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
 /// Workflow API methods
 /// Uses the form method_object
 impl super::Client {
@@ -217,13 +223,10 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Project>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("workflow").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!("{}{}", self.host, "/v1/projects/"))
             .query(&q)?
             .header("Authorization", at)
@@ -469,13 +472,10 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Task>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("workflow").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!(
             "{}{}{}{}",
             self.host, "/v1/projects/", id, "/tasks"
@@ -502,13 +502,10 @@ impl super::Client {
         offset: Option<u32>,
     ) -> Result<Vec<Task>, Box<dyn Error + Send + Sync + 'static>> {
         let at = self.get_access_token("workflow").await?;
-        let mut q: Vec<(&str, String)> = Vec::new();
-        if let Some(v) = limit {
-            q.push(("limit", v.to_string()));
-        }
-        if let Some(v) = offset {
-            q.push(("offset", v.to_string()));
-        }
+        let q = QueryParams {
+            limit,
+            offset,
+        };
         let mut response = surf::get(&format!(
             "{}{}{}{}{}{}",
             self.host, "/v1/projects/", project_id, "/lists/", list_id, "/tasks"


### PR DESCRIPTION
fix #4 serialization of URL query params

passing in a reference to Vec<&str, String> or [(&str, String)] won't
result in query params being serialized as expected.

Add locally scoped structs that impl Serialize to correctly generate
URL query params. This could probably be pulled out to a common place, but for the most part I just defined the structs in a localized scope to keep things simple in the event query params change for specific APIs

Also bumped surf version to latest